### PR TITLE
Fix: wrong tablename

### DIFF
--- a/Trilium-Heatmap/html/js.js
+++ b/Trilium-Heatmap/html/js.js
@@ -49,7 +49,7 @@ const datas = await api.runOnBackend(() => {
     const editedNotes = api.sql.getMap(`SELECT date , COUNT(*) FROM (
             SELECT noteId, SUBSTR(utcDateModified, 0, 11) AS date FROM notes
             UNION
-            SELECT DISTINCT noteId, SUBSTR(utcDateCreated, 0, 11) AS date FROM revisions
+            SELECT DISTINCT noteId, SUBSTR(utcDateCreated, 0, 11) AS date FROM note_revisions
         )
         GROUP BY date`);
     return editedNotes;


### PR DESCRIPTION
This commit will fix the "no revisions table" Error by correcting the SQL-Querry

# Symptoms:
Installing the plugin (zip and source-code) creates following error, if you open the Heatmap-note:
```
Error:

Execution of JS note "html" with ID 2d7MBG8AyO59 failed with error: Load of script note "js" (PN6CWzgPGpxL) failed with: server error: Load of script note "js" (PN6CWzgPGpxL) failed with: no such table: revisions
```

# Bug:
The bug is caused in line 52 of js.js:
```js
[49]    const editedNotes = api.sql.getMap(`SELECT date , COUNT(*) FROM (
[50]            SELECT noteId, SUBSTR(utcDateModified, 0, 11) AS date FROM notes
[51]            UNION
[52]            SELECT DISTINCT noteId, SUBSTR(utcDateCreated, 0, 11) AS date FROM revisions
[53]        )
[54]       GROUP BY date`);
```



# Fix
changing `FROM revisions` to `FROM note_revisions`

